### PR TITLE
feature: formatting a message with a given value verbose = true and/or parse_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ const logger = pino({
       chatId: -1234567890,
       botToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
       extra: {
-              parse_mode: "HTML",
-            },
+        parse_mode: "HTML",
+      },
     },
   },
 })
@@ -31,3 +31,29 @@ logger.error('<b>test log!</b>');
 ```
 
 The extra parameter is optional. Parameters that the method [sendMessage](https://core.telegram.org/bots/api#sendmessage) supports can be passed to it
+
+---
+
+If `verbose = true`, the message will be displayed as
+```
+{
+  "level": 50,
+  "time": 1721832322878,
+  "pid": 13522,
+  "hostname": "fedora",
+  "msg": "`inline fixed-width code`"
+}
+```
+
+---
+
+If `verbose = true` and `parse_mode = "HTML|Markdown|MarkdownV2`, the message will be displayed as
+```json
+{
+  "level": 50,
+  "time": 1721832322878,
+  "pid": 13522,
+  "hostname": "fedora",
+  "msg": "`inline fixed-width code`"
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
-"use strict";
-
-const build = require("pino-abstract-transport");
+import build from "pino-abstract-transport";
 
 const API_URL = "https://api.telegram.org/bot";
 
-const sendMsgToTg = async (chatId, botToken, text, extra = {}) => {
+export async function sendMsgToTg(chatId, botToken, message, extra = {}) {
   const method = "sendMessage";
   const url = `${API_URL}${botToken}/${method}`;
+  const body = JSON.stringify({
+    chat_id: chatId,
+    text: message,
+    ...extra,
+  });
+
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      chat_id: chatId,
-      text: text,
-      ...extra,
-    }),
+    body,
   });
 
   if (response.ok) {
@@ -30,26 +30,50 @@ const sendMsgToTg = async (chatId, botToken, text, extra = {}) => {
 
   const { status, statusText } = response;
   throw new Error(`${status}: ${statusText}`);
+}
+
+const verboseSerializer = {
+  html: (string) => `<pre><code class="language-json">${string}</code></pre>`,
+  markdown: (string) => `\`\`\`json\n${string}\n\`\`\``,
+  markdownv2: (string) => `\`\`\`json\n${string}\n\`\`\``,
+};
+
+const prepareMessage = (pinoData, verbose, parseMode) => {
+  if (verbose) {
+    const msg = JSON.stringify(pinoData, null, 2);
+
+    if (parseMode) {
+      const parseModeLC = parseMode.toLowerCase();
+      const serializer = verboseSerializer[parseModeLC];
+      return serializer(msg);
+    }
+
+    return msg;
+  }
+
+  return pinoData.msg;
 };
 
 /**
  *
- * @param {object} params - параметры для создания транспорта
- * @param {number} params.chatId - идентификатор чата
- * @param {string} params.botToken - токен бота
- * @param {boolean} params.verbose - отправить отладочную информацию
- * @param {object} params.extra - дополнительные параметры для отправки сообщения https://core.telegram.org/bots/api#sendmessage
+ * @param {object} params - parameters for creating a transport
+ * @param {number} params.chatId - chat ID
+ * @param {string} params.botToken - bot token
+ * @param {boolean} params.verbose - send debugging information
+ * @param {object} params.extra - additional parameters for sending a message https://core.telegram.org/bots/api#sendmessage
  * @returns {Promise}
  */
-module.exports = function ({ chatId, botToken, verbose = false, extra = {} }) {
+export default function ({ chatId, botToken, verbose = false, extra = {} }) {
   return build(async function (source) {
     for await (const obj of source) {
-      const text = verbose ? JSON.stringify(obj) : obj.msg;
+      const { parse_mode } = extra;
+      const message = prepareMessage(obj, verbose, parse_mode);
+
       try {
-        await sendMsgToTg(chatId, botToken, text, extra);
+        await sendMsgToTg(chatId, botToken, message, extra);
       } catch (error) {
         console.error(error);
       }
     }
   });
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pino-telegram-webhook",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pino-telegram-webhook",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "pino-abstract-transport": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-telegram-webhook",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "A [Pino v7+ transport](https://getpino.io/#/docs/transports?id=v7-transports) to send message to [Telegram](https://telegram.org/)",
   "keywords": [
     "pino",


### PR DESCRIPTION
If `verbose = true`, the message will be displayed as
```
{
  "level": 50,
  "time": 1721832322878,
  "pid": 13522,
  "hostname": "fedora",
  "msg": "`inline fixed-width code`"
}
```

---

If `verbose = true` and `parse_mode = "HTML|Markdown|MarkdownV2`, the message will be displayed as
```json
{
  "level": 50,
  "time": 1721832322878,
  "pid": 13522,
  "hostname": "fedora",
  "msg": "`inline fixed-width code`"
}
```
