### PR TITLE
Added missing link for parse_mode option

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ export default function ({
         const message = prepareMessage({
           pinoData,
           verbose,
-          parse_mode,
+          parseMode: parse_mode,
           messageKey,
         });
 


### PR DESCRIPTION
This issue is caused by the key used by Telegram (and hence in the `extra` option) being `parse_mode`, while the `prepareMessage()` expects `parseMode`, causing the parse mode to be ignored in the message preparation.

This should resolve "Bad Request: can't parse entities" error whenever `parse_mode` is being set and `verbose` is set to `true`.